### PR TITLE
Include unistd.h explicitly

### DIFF
--- a/src/scim_hangul_imengine.cpp
+++ b/src/scim_hangul_imengine.cpp
@@ -34,6 +34,7 @@
 #endif
 
 #include <cstring>
+#include <unistd.h>
 #include <scim.h>
 #include "scim_hangul_imengine.h"
 


### PR DESCRIPTION
This patch solves the following errors:

scim_hangul_imengine.cpp:139:37: error: ‘R_OK’ was not declared in this scope
scim_hangul_imengine.cpp:139:41: error: ‘access’ was not declared in this scope
scim_hangul_imengine.cpp:143:34: error: ‘R_OK’ was not declared in this scope
scim_hangul_imengine.cpp:143:38: error: ‘access’ was not declared in this scope
