### PR TITLE
Fix build with GTK 2.24.

### DIFF
--- a/src/scim_hangul_imengine_setup.cpp
+++ b/src/scim_hangul_imengine_setup.cpp
@@ -346,7 +346,7 @@ create_keyboard_page(GtkTooltips *tooltips)
     for (i = 0; i < n; i++) {
 	const char* name = hangul_ic_get_keyboard_name(i);
 #if GTK_CHECK_VERSION(2, 24, 0)
-	gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(combo_box), NULL, name);
+	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combo_box), name);
 #else
 	gtk_combo_box_append_text(GTK_COMBO_BOX(combo_box), name);
 #endif


### PR DESCRIPTION
This fixes build with GTK 2.24.  For more info, please read this (found by googling):

http://stackoverflow.com/questions/6260674/gtk-documentation-typo-undefined-reference-to-gtk-combo-box-text-append
